### PR TITLE
Remove DICOM upload instructions from user-facing docs

### DIFF
--- a/docs/notebooks/dicom_access.ipynb
+++ b/docs/notebooks/dicom_access.ipynb
@@ -237,39 +237,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41847b6e-ed15-4dbf-8818-fa5978f8780e",
-   "metadata": {},
-   "source": [
-    "## (Optional, for testing here only) Upload to the DICOM service with `multipart\\related`\n",
-    "Following [Azure docs](https://learn.microsoft.com/en-us/azure/healthcare-apis/dicom/dicomweb-standard-apis-python#store-instances-using-multipartrelated)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7abae92b-0637-404b-8d12-52df4a1a7013",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dcm_filepath = filename_ct\n",
-    "\n",
-    "with open(dcm_filepath,'rb') as reader:\n",
-    "    rawfile = reader.read()\n",
-    "files = {'file': ('dicomfile', rawfile, 'application/dicom')}\n",
-    "\n",
-    "#encode as multipart_related\n",
-    "body, content_type = encode_multipart_related(fields = files)\n",
-    "\n",
-    "headers = {'Accept':'application/dicom+json', \"Content-Type\":content_type, \"Authorization\":bearer_token}\n",
-    "\n",
-    "url = f'{base_url}/studies'\n",
-    "response = client.post(url, body, headers=headers, verify=False)\n",
-    "# Response will be 409 if asset already uploaded\n",
-    "print(response.status_code, response.content)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "82351f46-777a-4f2a-acd8-cdeacbab4e77",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Removes instructions for adding DICOM data to the DICOM service via a `POST` request from the end user facing docs as was only intended for testing and shouldn't be supported going forward.